### PR TITLE
wp_register_script() parameters definition has changed in WP 6.3

### DIFF
--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1610,10 +1610,10 @@ function wp_rand( $min = 0, $max = 0 ) {
 }
 
 /**
- * @param string                          $handle
- * @param string|bool                     $src
- * @param array<string>                   $deps
- * @param string|bool|null                $ver
+ * @param string                                $handle
+ * @param string|bool                           $src
+ * @param array<string>                         $deps
+ * @param string|bool|null                      $ver
  * @param array{0: string, 1: string|bool}|bool $args
  *
  * @return bool

--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1614,7 +1614,7 @@ function wp_rand( $min = 0, $max = 0 ) {
  * @param string|bool                     $src
  * @param array<string>                   $deps
  * @param string|bool|null                $ver
- * @param array{string, string|bool}|bool $args
+ * @param array{0:string, 1:string|bool}|bool $args
  *
  * @return bool
  */

--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1610,11 +1610,14 @@ function wp_rand( $min = 0, $max = 0 ) {
 }
 
 /**
- * @param string                                $handle
- * @param string|bool                           $src
- * @param array<string>                         $deps
- * @param string|bool|null                      $ver
- * @param array{0: string, 1: string|bool}|bool $args
+ * @param string                                          $handle
+ * @param string|bool                                     $src
+ * @param array<string>                                   $deps
+ * @param string|bool|null                                $ver
+ * @param bool|array{strategy?: string, in_footer?: bool} $args {
+ *     @type string $strategy
+ *     @type bool $in_footer
+ * }
  *
  * @return bool
  */

--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1614,7 +1614,7 @@ function wp_rand( $min = 0, $max = 0 ) {
  * @param string|bool                     $src
  * @param array<string>                   $deps
  * @param string|bool|null                $ver
- * @param array{0:string, 1:string|bool}|bool $args
+ * @param array{0: string, 1: string|bool}|bool $args
  *
  * @return bool
  */

--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1614,11 +1614,11 @@ function wp_rand( $min = 0, $max = 0 ) {
  * @param string|bool      $src
  * @param array<string>    $deps
  * @param string|bool|null $ver
- * @param bool             $in_footer
+ * @param array|bool       $args
  *
  * @return bool
  */
-function wp_register_script( $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
+function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args = array() ) {
 }
 
 /**

--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1610,11 +1610,11 @@ function wp_rand( $min = 0, $max = 0 ) {
 }
 
 /**
- * @param string           $handle
- * @param string|bool      $src
- * @param array<string>    $deps
- * @param string|bool|null $ver
- * @param array|bool       $args
+ * @param string                          $handle
+ * @param string|bool                     $src
+ * @param array<string>                   $deps
+ * @param string|bool|null                $ver
+ * @param array<string, string|bool>|bool $args
  *
  * @return bool
  */

--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1614,7 +1614,7 @@ function wp_rand( $min = 0, $max = 0 ) {
  * @param string|bool                     $src
  * @param array<string>                   $deps
  * @param string|bool|null                $ver
- * @param array<string, string|bool>|bool $args
+ * @param array{string, string|bool}|bool $args
  *
  * @return bool
  */


### PR DESCRIPTION
wp_register_script() parameters definition has changed in WP 6.3
https://developer.wordpress.org/reference/functions/wp_register_script/#changelog