### PR TITLE
WP_Admin_Bar & WP_Widget classes

### DIFF
--- a/stubs/WordPress/class-wp-admin-bar.php
+++ b/stubs/WordPress/class-wp-admin-bar.php
@@ -8,13 +8,13 @@ declare(strict_types = 1);
 class WP_Admin_Bar {
 
 	/**
-	 * @param array{id: string, title?: string, parent?: string|false|null, href?: string, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string, tabindex?: string}} $node {
-	 *     @type string            $id
-	 *     @type string            $title
-	 *     @type string|false|null $parent
-	 *     @type string            $href
-	 *     @type bool              $group
-	 *     @type array             $meta
+	 * @param array{id: string|false|null, title?: string|false|null, parent?: string|false|null, href?: string|false|null, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $node {
+	 *     @type string|false|null  $id
+	 *     @type string|false|null  $title
+	 *     @type string|false|null  $parent
+	 *     @type string|false|null  $href
+	 *     @type bool               $group
+	 *     @type array              $meta
 	 * }
 	 *
 	 * @return void
@@ -23,10 +23,19 @@ class WP_Admin_Bar {
 	}
 
 	/**
-	 * @param string $id
+	 * @param array{id: string|false|null, title?: string|false|null, parent?: string|false|null, href?: string|false|null, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $args {
+	 *     Arguments for adding a node.
 	 *
-	 * @return object|null
+	 *     @type string|false|null $id     ID of the item.
+	 *     @type string|false|null $title  Title of the node.
+	 *     @type string|false|null $parent Optional. ID of the parent node.
+	 *     @type string|false|null $href   Optional. Link for the item.
+	 *     @type bool              $group  Optional. Whether or not the node is a group. Default false.
+	 *     @type array             $meta   Meta data including the following keys: 'html', 'class', 'rel', 'lang', 'dir',
+	 *                                  'onclick', 'target', 'title', 'tabindex', 'menu_title'. Default empty.
+	 * }
+	 * @return void
 	 */
-	public function get_node( $id ) {
+	public function get_node( $args ) {
 	}
 }

--- a/stubs/WordPress/class-wp-admin-bar.php
+++ b/stubs/WordPress/class-wp-admin-bar.php
@@ -34,7 +34,7 @@ class WP_Admin_Bar {
 	 *     @type bool         $group  Optional. Whether or not the node is a group. Default false.
 	 *     @type array        $meta   Meta data including the following keys: 'html', 'class', 'rel', 'lang', 'dir',
 	 *                                  'onclick', 'target', 'title', 'tabindex', 'menu_title'. Default empty.
-	 * }|void
+	 * }
 	 */
 	public function get_node( $id ) {
 	}

--- a/stubs/WordPress/class-wp-admin-bar.php
+++ b/stubs/WordPress/class-wp-admin-bar.php
@@ -23,8 +23,8 @@ class WP_Admin_Bar {
 	}
 
 	/**
-	 * @param string $args
-	 * @return array{id: string, title?: string|false, parent?: string|false, href?: string|false, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $args {
+	 * @param string $id
+	 * @return array{id: string, title?: string|false, parent?: string|false, href?: string|false, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}}|void {
 	 *     Arguments for adding a node.
 	 *
 	 *     @type string       $id     ID of the item.
@@ -34,8 +34,8 @@ class WP_Admin_Bar {
 	 *     @type bool         $group  Optional. Whether or not the node is a group. Default false.
 	 *     @type array        $meta   Meta data including the following keys: 'html', 'class', 'rel', 'lang', 'dir',
 	 *                                  'onclick', 'target', 'title', 'tabindex', 'menu_title'. Default empty.
-	 * }
+	 * }|void
 	 */
-	public function get_node( $args ) {
+	public function get_node( $id ) {
 	}
 }

--- a/stubs/WordPress/class-wp-admin-bar.php
+++ b/stubs/WordPress/class-wp-admin-bar.php
@@ -8,13 +8,13 @@ declare(strict_types = 1);
 class WP_Admin_Bar {
 
 	/**
-	 * @param array{id: string, title?: string, parent?: string, href?: string, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string, tabindex?: string}} $node {
-	 *     @type string $id
-	 *     @type string $title
-	 *     @type string $parent
-	 *     @type string $href
-	 *     @type bool   $group
-	 *     @type array  $meta
+	 * @param array{id: string, title?: string, parent?: string|false|null, href?: string, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string, tabindex?: string}} $node {
+	 *     @type string            $id
+	 *     @type string            $title
+	 *     @type string|false|null $parent
+	 *     @type string            $href
+	 *     @type bool              $group
+	 *     @type array             $meta
 	 * }
 	 *
 	 * @return void

--- a/stubs/WordPress/class-wp-admin-bar.php
+++ b/stubs/WordPress/class-wp-admin-bar.php
@@ -8,13 +8,13 @@ declare(strict_types = 1);
 class WP_Admin_Bar {
 
 	/**
-	 * @param array{id: string|false|null, title?: string|false|null, parent?: string|false|null, href?: string|false|null, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $node {
-	 *     @type string|false|null  $id
-	 *     @type string|false|null  $title
-	 *     @type string|false|null  $parent
-	 *     @type string|false|null  $href
-	 *     @type bool               $group
-	 *     @type array              $meta
+	 * @param array{id: string, title?: string|false, parent?: string|false, href?: string|false, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $node {
+	 *     @type string        $id
+	 *     @type string|false  $title
+	 *     @type string|false  $parent
+	 *     @type string|false  $href
+	 *     @type bool          $group
+	 *     @type array         $meta
 	 * }
 	 *
 	 * @return void
@@ -23,18 +23,18 @@ class WP_Admin_Bar {
 	}
 
 	/**
-	 * @param array{id: string|false|null, title?: string|false|null, parent?: string|false|null, href?: string|false|null, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $args {
+	 * @param string $args
+	 * @return array{id: string, title?: string|false, parent?: string|false, href?: string|false, group?: bool, meta?: array{html?: string, class?: string, rel?: string, onclick?: string, target?: string, title?: string|false, tabindex?: string}} $args {
 	 *     Arguments for adding a node.
 	 *
-	 *     @type string|false|null $id     ID of the item.
-	 *     @type string|false|null $title  Title of the node.
-	 *     @type string|false|null $parent Optional. ID of the parent node.
-	 *     @type string|false|null $href   Optional. Link for the item.
-	 *     @type bool              $group  Optional. Whether or not the node is a group. Default false.
-	 *     @type array             $meta   Meta data including the following keys: 'html', 'class', 'rel', 'lang', 'dir',
+	 *     @type string       $id     ID of the item.
+	 *     @type string|false $title  Title of the node.
+	 *     @type string|false $parent Optional. ID of the parent node.
+	 *     @type string|false $href   Optional. Link for the item.
+	 *     @type bool         $group  Optional. Whether or not the node is a group. Default false.
+	 *     @type array        $meta   Meta data including the following keys: 'html', 'class', 'rel', 'lang', 'dir',
 	 *                                  'onclick', 'target', 'title', 'tabindex', 'menu_title'. Default empty.
 	 * }
-	 * @return void
 	 */
 	public function get_node( $args ) {
 	}

--- a/stubs/WordPress/class-wp-widget.php
+++ b/stubs/WordPress/class-wp-widget.php
@@ -43,4 +43,18 @@ class WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 	}
+
+	/**
+	 * @param string $field_name
+	 * @return string
+	 */
+	public function get_field_id( $field_name ) {
+	}
+
+	/**
+	 * @param string $field_name
+	 * @return string
+	 */
+	public function get_field_name( $field_name ) {
+	}
 }


### PR DESCRIPTION
[add_menu](https://developer.wordpress.org/reference/classes/wp_admin_bar/add_menu/) method is incorrect in WordPress documentation. `get_node()` was outdated.

Most properties can be `string|false`, but also `null` since they are default properties.

Updated `get_node()` to match `add_menu`, since the latter is a wrapper of the former.