### PR TITLE
set_transient() third param $expiration is optional

### DIFF
--- a/stubs/WordPress/functions.php
+++ b/stubs/WordPress/functions.php
@@ -1152,7 +1152,7 @@ function set_theme_mod( $name, $value ) {
  *
  * @return bool
  */
-function set_transient( $transient, $value, $expiration ) {
+function set_transient( $transient, $value, $expiration = 0 ) {
 }
 
 /**


### PR DESCRIPTION
According to 
https://developer.wordpress.org/reference/functions/set_transient/