### PR TITLE
Format YAML files and unify the dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,17 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  open-pull-requests-limit: 9999
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
-- package-ecosystem: composer
-  directory: "/"
-  open-pull-requests-limit: 9999
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
+  - package-ecosystem: github-actions
+    directory: "/"
+    open-pull-requests-limit: 9999
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic
+  - package-ecosystem: composer
+    directory: "/"
+    open-pull-requests-limit: 9999
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,13 @@ updates:
     directory: "/"
     open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic
   - package-ecosystem: composer
     directory: "/"
     open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
+---
 name: "CI"
-on:
+"on":
   push:
     branches: "*"
   pull_request:
@@ -7,7 +8,7 @@ env:
   php-version: 8.4
   cache-version: 1
 jobs:
-   lint:
+  lint:
     name: "Lint"
     runs-on: ubuntu-latest
     env:
@@ -42,7 +43,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.composer/cache"
-          key: composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
+          key: >-
+            composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('composer.json') }}
           restore-keys: |
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,6 @@
+---
 name: "Dependabot auto-merge"
-on: "pull_request_target"
+"on": "pull_request_target"
 
 permissions:
   pull-requests: write
@@ -13,12 +14,14 @@ jobs:
     steps:
       - name: "Fetch Dependabot metadata"
         id: "metadata"
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Enable auto-merge for the request"
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: >-
+          ${{ steps.metadata.outputs.update-type !=
+          'version-update:semver-major' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Two independent commits; they can be reviewed separately.

## 1. `Format and lint YAML files`

Conform every YAML file in the repository to yamllint's default rules,
which previously reported a large number of issues:

- Add the `---` document start marker.
- Quote the `on:` workflow key so it is not parsed as the boolean true.
- Indent block sequences under their parent key, which was previously
  inconsistent even within a single file.
- Fold over-long values into `>-` block scalars. Every folded value is
  preserved byte for byte.

Beyond formatting:

- Bump dependabot/fetch-metadata from v2.5.0 to v3.1.0, matching the
  version already used in the other repositories.
- Fix the indentation of the `lint:` job, which was indented three spaces
  instead of two.

Verified by comparing every file before and after as parsed YAML: apart
from the changes listed above, no key or value differs. The remaining
long lines are `restore-keys` entries and shell lines inside `run: |`
blocks, which cannot be wrapped without changing their meaning.

## 2. `Unify the dependabot schedule across repositories`

Set every dependabot ecosystem to a weekly schedule with an effectively
unlimited number of open pull requests:

- `interval: weekly`
- `open-pull-requests-limit: 9999` (GitHub's default is 5)

Until now these settings tracked whether the repository had dependabot
auto-merge: the repositories with it used weekly/9999, while those without
used daily and the default limit, so that dependency PRs arrived in small
batches for manual review. Auto-merge is now enabled everywhere, so that
distinction no longer applies.

Ecosystems, directories and assignees are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)